### PR TITLE
pkp/pkp-lib#2051 Add review form responses to comments field if they are present

### DIFF
--- a/ReviewReportDAO.inc.php
+++ b/ReviewReportDAO.inc.php
@@ -59,6 +59,7 @@ class ReviewReportDAO extends DAO {
 		);
 		$reviewsReturner = new DBRowIterator($this->retrieve(
 			'SELECT	r.stage_id AS stage_id,
+				r.review_id as review_id,
 				r.round AS round,
 				COALESCE(asl.setting_value, aspl.setting_value) AS submission,
 				a.submission_id AS submission_id,
@@ -116,4 +117,3 @@ class ReviewReportDAO extends DAO {
 		return array($commentsReturner, $reviewsReturner, $interests);
 	}
 }
-


### PR DESCRIPTION
Hi Alec,

This commit brings in the code that adds the review form responses to the "comments" column that exists in the report but is otherwise empty if journals are using review form responses instead of just the comments field. We implemented this as a customization for a hosted journal who have tested it and it may be useful for others.

Cheers,
Jason